### PR TITLE
feat: add Dependabot configuration and GitHub workflows for build and release automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for more information:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://containers.dev/guide/dependabot
+
+version: 2
+updates:
+ - package-ecosystem: "devcontainers"
+   directory: "/"
+   schedule:
+     interval: weekly

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,47 @@
+name: Build
+
+on:
+  pull_request:
+    branches:
+      - "main"
+
+jobs:
+  build-artifacts:
+    if: ${{ !contains(github.event.head_commit.message, 'docs:') || github.event.pull_request.head.repo.fork == false }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      issues: write
+    steps:
+      # checkout
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # git status
+      - name: Git status
+        run: git status
+
+      - name: Determine Branch
+        id: branch
+        uses: transferwise/sanitize-branch-name@v1
+
+      # build
+      - name: build artifacts
+        id: build_artifacts
+        uses: goreleaser/goreleaser-action@v5
+        with:
+          version: latest
+          args: release --snapshot --clean --config .gorelease.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH_NAME: ${{ steps.branch.outputs.sanitized-branch-name }}
+
+      # artifacts
+      - name: Push linux artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build_linux
+          path: dist/*linux*

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -34,7 +34,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v5
         with:
           version: latest
-          args: release --snapshot --clean --config .gorelease.yml
+          args: release --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH_NAME: ${{ steps.branch.outputs.sanitized-branch-name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Build
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+jobs:
+  build-artifacts:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+      issues: write
+    steps:
+      - uses: actions/setup-go@v5
+        with:
+          go-version: 1.23
+
+      # checkout
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # git status
+      - name: Git status
+        run: git status
+
+      # build
+      - name: Release
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,46 @@
+# https://goreleaser.com
+project_name: nntpservermock
+
+builds:
+  - goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    main: ./main.go
+    ldflags:
+      - -s -w
+      - -X "main.Version={{ .Version }}"
+      - -X "main.GitCommit={{ .ShortCommit }}"
+      - -X "main.Timestamp={{ .Timestamp }}"
+    ignore:
+      - goos: windows
+        goarch: arm64
+    flags:
+      - -trimpath
+universal_binaries:
+  - replace: true
+archives:
+  - format: tar.gz
+    # this name template makes the OS and Arch compatible with the results of uname.
+    name_template: '{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
+
+    # use zip for windows archives
+    format_overrides:
+      - goos: windows
+        format: zip
+
+# Checksum
+checksum:
+  name_template: 'checksums.txt'
+  algorithm: sha512
+
+# Changelog
+changelog:
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^Merge branch'

--- a/main.go
+++ b/main.go
@@ -19,7 +19,10 @@ func main() {
 	maybefatal(err, "Error setting up listener: %v", err)
 	defer l.Close()
 
-	backend := nntpserver.NewDiskBackend()
+	backend := nntpserver.NewDiskBackend(
+		false,
+		"",
+	)
 	s := nntpserver.NewServer(backend)
 
 	fmt.Printf("Server listening on port %s\n", port)


### PR DESCRIPTION
This pull request includes several significant changes to automate dependency updates, improve CI/CD workflows, and enhance the `DiskBackend` implementation in the `nntpserver` package.

### Automation and CI/CD Enhancements:

* **Dependabot Configuration**:
  - Added a `.github/dependabot.yml` file to automate dependency updates for the `devcontainers` package ecosystem on a weekly schedule.

* **GitHub Actions Workflows**:
  - Added a new workflow `.github/workflows/pull-request.yml` to build artifacts on pull requests to the `main` branch, excluding documentation changes from forks.
  - Added a new workflow `.github/workflows/release.yml` to build and release artifacts when a new tag matching the pattern `v*.*.*` is pushed.

### Codebase Enhancements:

* **GoReleaser Configuration**:
  - Introduced a `.goreleaser.yml` file to configure GoReleaser for building and releasing artifacts for multiple OS and architecture combinations, including checksum and changelog generation.

* **`DiskBackend` Implementation**:
  - Updated the `DiskBackend` constructor to accept `cleanOnClose` and `dbPath` parameters, allowing for more flexible backend configuration.
  - Modified the `Close` method to optionally reset and remove the database file if `cleanOnClose` is set to `true`.
  - Updated the `main.go` file to pass the new parameters to `NewDiskBackend`.
  - Added the `os` package import in `nntpserver/disk_backend.go` to support file operations.